### PR TITLE
adding --noSeparator override

### DIFF
--- a/dynamodump.py
+++ b/dynamodump.py
@@ -329,7 +329,7 @@ parser.add_argument("-r", "--region", help="AWS region to use, e.g. 'us-west-1'.
 parser.add_argument("-s", "--srcTable", help="Source DynamoDB table name to backup or restore from, use 'tablename*' for wildcard prefix selection")
 parser.add_argument("-d", "--destTable", help="Destination DynamoDB table name to backup or restore to, use 'tablename*' for wildcard prefix selection (defaults to use '-' separator) [optional, defaults to source]")
 parser.add_argument("--prefixSeparator", help="Specify a different prefix separator, e.g. '.' [optional]")
-parser.add_argument("--noPrefix", action='store_true', help="Override flag the use of a prefix separator for backup wildcard searches, [optional]")
+parser.add_argument("--noSeparator", action='store_true', help="Override flag the use of a prefix separator to use backup wildcard searches, [optional]")
 parser.add_argument("--readCapacity", help="Change the temp read capacity of the DynamoDB table to backup from [optional]")
 parser.add_argument("--writeCapacity", help="Change the temp write capacity of the DynamoDB table to restore to [defaults to " + str(RESTORE_WRITE_CAPACITY) + ", optional]")
 parser.add_argument("--host", help="Host of local DynamoDB [required only for local]")
@@ -357,7 +357,7 @@ else:
 prefix_separator = DEFAULT_PREFIX_SEPARATOR
 if args.prefixSeparator != None:
   prefix_separator = args.prefixSeparator
-if args.noPrefix == True :
+if args.noSeparator == True :
   prefix_separator = None
 
 # do backup/restore


### PR DESCRIPTION
Thank you for providing dynamo dump, it's great to backup/migrate tables between AWS zone and development life cycles.

In previous versions (prior to the separator) flag I was performing backups using '*' wildcard with a naming convention which didn't include prefixes

prodTable1
prodTable2
devTable1
devTable2
devTable3
stagingTable1

I could then do wildcard backups using tablename 'dev*' however this changed with the introduction of the separator.

I've added an override flag to the prefix separator to re-implement the wildcard functionality as it previously worked.

parser.add_argument("--noSeparator", action='store_true', help="Override flag the use of a prefix separator to use backup wildcard searches, [optional]")

I hope you might consider this pull request, it's semi-related to https://github.com/bchew/dynamodump/issues/6
