### PR TITLE
Adding --noSeparator flag to enable backup wildcard table matching

### DIFF
--- a/dynamodump.py
+++ b/dynamodump.py
@@ -32,7 +32,10 @@ def get_table_name_matches(conn, table_name_wildcard, separator):
 
   matching_tables = []
   for table_name in all_tables:
-    if table_name.split(separator, 1)[0] == table_name_wildcard.split("*", 1)[0]:
+    if separator == None:
+      if table_name.startswith(table_name_wildcard.split("*", 1)[0]):
+        matching_tables.append(table_name)
+    elif table_name.split(separator, 1)[0] == table_name_wildcard.split("*", 1)[0]:
       matching_tables.append(table_name)
 
   return matching_tables
@@ -326,6 +329,7 @@ parser.add_argument("-r", "--region", help="AWS region to use, e.g. 'us-west-1'.
 parser.add_argument("-s", "--srcTable", help="Source DynamoDB table name to backup or restore from, use 'tablename*' for wildcard prefix selection")
 parser.add_argument("-d", "--destTable", help="Destination DynamoDB table name to backup or restore to, use 'tablename*' for wildcard prefix selection (defaults to use '-' separator) [optional, defaults to source]")
 parser.add_argument("--prefixSeparator", help="Specify a different prefix separator, e.g. '.' [optional]")
+parser.add_argument("--noSeparator", action='store_true', help="Overrides the use of a prefix separator for backup wildcard searches, [optional]")
 parser.add_argument("--readCapacity", help="Change the temp read capacity of the DynamoDB table to backup from [optional]")
 parser.add_argument("--writeCapacity", help="Change the temp write capacity of the DynamoDB table to restore to [defaults to " + str(RESTORE_WRITE_CAPACITY) + ", optional]")
 parser.add_argument("--host", help="Host of local DynamoDB [required only for local]")
@@ -353,6 +357,8 @@ else:
 prefix_separator = DEFAULT_PREFIX_SEPARATOR
 if args.prefixSeparator != None:
   prefix_separator = args.prefixSeparator
+if args.noSeparator == True:
+  prefix_separator = None  
 
 # do backup/restore
 start_time = datetime.datetime.now().replace(microsecond=0)


### PR DESCRIPTION
Revised pull request with single commit, space removed as per comment in https://github.com/bchew/dynamodump/pull/7
