### PR TITLE
Increase control over logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ nosetests.xml
 .pydevproject
 
 dump
+
+# Logging
+logging.config

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ optional arguments:
                         Access key of local DynamoDB [required only for local]
   --secretKey SECRETKEY
                         Secret key of local DynamoDB [required only for local]
-  --log LOG             Logging level - DEBUG|INFO|WARNING|ERROR|CRITICAL
+  --logConfig path      The path to logging config, if not provided will try to pick logging.config if not found then logging.config.dist
                         [optional]
 
 

--- a/dynamodump.py
+++ b/dynamodump.py
@@ -336,7 +336,7 @@ parser.add_argument("--host", help="Host of local DynamoDB [required only for lo
 parser.add_argument("--port", help="Port of local DynamoDB [required only for local]")
 parser.add_argument("--accessKey", help="Access key of local DynamoDB [required only for local]")
 parser.add_argument("--secretKey", help="Secret key of local DynamoDB [required only for local]")
-parser.add_argument("--logConfig", help="The log config")
+parser.add_argument("--logConfig", help="The path to logging config, if not provided will try to pick logging.config if not found then logging.config.dist")
 args = parser.parse_args()
 
 # set the logging config

--- a/dynamodump.py
+++ b/dynamodump.py
@@ -336,14 +336,17 @@ parser.add_argument("--host", help="Host of local DynamoDB [required only for lo
 parser.add_argument("--port", help="Port of local DynamoDB [required only for local]")
 parser.add_argument("--accessKey", help="Access key of local DynamoDB [required only for local]")
 parser.add_argument("--secretKey", help="Secret key of local DynamoDB [required only for local]")
-parser.add_argument("--log", help="Logging level - DEBUG|INFO|WARNING|ERROR|CRITICAL [optional]")
+parser.add_argument("--logConfig", help="The log config")
 args = parser.parse_args()
 
-# set log level
-log_level = LOG_LEVEL
-if args.log != None:
-  log_level = args.log.upper()
-logging.basicConfig(level=getattr(logging, log_level))
+# set the logging config
+loggingFilename = 'logging.config.dist'
+if os.path.isfile('logging.config'):
+  loggingFilename = 'logging.config'
+if args.logConfig is not None:
+  loggingFilename = args.logConfig
+
+logging.config.fileConfig(loggingFilename)
 
 # instantiate connection
 if args.region == LOCAL_REGION:

--- a/dynamodump.py
+++ b/dynamodump.py
@@ -10,7 +10,6 @@ SCHEMA_FILE = "schema.json"
 DATA_DIR = "data"
 MAX_RETRY = 6
 LOCAL_REGION = "local"
-LOG_LEVEL = "INFO"
 DUMP_PATH = "dump"
 RESTORE_WRITE_CAPACITY = 100
 THREAD_START_DELAY = 1 #seconds

--- a/logging.config.dist
+++ b/logging.config.dist
@@ -1,0 +1,25 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=basicFormatter
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=basicFormatter
+args=(sys.stdout,)
+
+[formatter_basicFormatter]
+# The default format of logging
+format=%(levelname)s:%(name)s:%(message)s
+# Format like: [2014-12-02 01:20:27,417] INFO:
+;format=[%(asctime)s] %(levelname)s: %(message)s
+datefmt=


### PR DESCRIPTION
I would like to have more control over logging, this ticket try to do that.

I had to drop the support to --log level, because I wasn't able to found a way to change on runtime the level of logging once is read from configuration

Eg:

```php
$ python2.7 dynamodump.py -m backup -r local --host 127.0.0.1 --port 4567 --accessKey key --secretKey secret -s foobars 
[2014-12-02 01:26:34,880] INFO: Starting backup for foobars..
[2014-12-02 01:26:34,880] INFO: Dumping table schema for foobars
[2014-12-02 01:26:34,884] INFO: Dumping table items for foobars
[2014-12-02 01:26:34,886] INFO: Backup for foobars table completed. Time taken: 0:00:00
```