### PR TITLE
Implement a capacity ratio on restore of tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ optional arguments:
   --writeCapacity WRITECAPACITY
                         Change the temp write capacity of the DynamoDB table
                         to restore to [defaults to 100, optional]
+  --restoreCapacityRatio
+                        Ratio that defines the final capacity of restored table. By default is 1.
+                        Use 2 to get the double capacity and 0.1 to get 10%
+                        [optional]
   --host HOST           Host of local DynamoDB [required only for local]
   --port PORT           Port of local DynamoDB [required only for local]
   --accessKey ACCESSKEY


### PR DESCRIPTION
The schema:
```json
{
  "Table": {
    "AttributeDefinitions": [
      {
        "AttributeName": "id", 
        "AttributeType": "S"
      }
    ], 
    "ProvisionedThroughput": {
      "WriteCapacityUnits": 5, 
      "NumberOfDecreasesToday": 0, 
      "ReadCapacityUnits": 5
    }, 
    "TableSizeBytes": 0, 
    "TableName": "foobars", 
    "TableStatus": "ACTIVE", 
    "KeySchema": [
      {
        "KeyType": "HASH", 
        "AttributeName": "id"
      }
    ], 
    "ItemCount": 0, 
    "CreationDateTime": 1417464793.808
  }
}
```

On use:

```
$ python2.7 dynamodump.py -m restore -r local --host 127.0.0.1 --port 4567 --accessKey AKIAILPOISCA3646H5PQ --secretKey secret -s foobars -d foobars-bak --restoreCapacityRatio 0.3
INFO:root:foobars-bak table deleted!
INFO:root:Starting restore for foobars to foobars-bak..
INFO:root:Creating foobars-bak table with temp write capacity of 100
INFO:root:foobars-bak created.
INFO:root:Restoring data for foobars-bak table..
INFO:root:Processing 0001.json of foobars-bak
INFO:root:Updating foobars-bak table read capacity to: 2, write capacity to: 2
INFO:root:Restore for foobars to foobars-bak table completed. Time taken: 0:00:00

$ python2.7 dynamodump.py -m restore -r local --host 127.0.0.1 --port 4567 --accessKey AKIAILPOISCA3646H5PQ --secretKey secret -s foobars -d foobars-bak --restoreCapacityRatio 3
INFO:root:foobars-bak table deleted!
INFO:root:Starting restore for foobars to foobars-bak..
INFO:root:Creating foobars-bak table with temp write capacity of 100
INFO:root:foobars-bak created.
INFO:root:Restoring data for foobars-bak table..
INFO:root:Processing 0001.json of foobars-bak
INFO:root:Updating foobars-bak table read capacity to: 15, write capacity to: 15
INFO:root:Restore for foobars to foobars-bak table completed. Time taken: 0:00:00
```