### PR TITLE
support blank prefix separator and use case instead

### DIFF
--- a/dynamodump.py
+++ b/dynamodump.py
@@ -88,7 +88,7 @@ def change_prefix(source_table_name, source_wildcard, destination_wildcard, sepa
     source_prefix = source_wildcard.split("*", 1)[0]
     destination_prefix = destination_wildcard.split("*", 1)[0]
     if separator == '':
-        if re.sub( r"([A-Z])", r" \1", source_table_name).split()[0] == source_prefix:
+        if re.sub(r"([A-Z])", r" \1", source_table_name).split()[0] == source_prefix:
             return destination_prefix + re.sub(r"([A-Z])", r" \1", source_table_name).split(' ', 1)[1].replace(" ", "")
     if source_table_name.split(separator, 1)[0] == source_prefix:
         return destination_prefix + separator + source_table_name.split(separator, 1)[1]

--- a/dynamodump.py
+++ b/dynamodump.py
@@ -51,7 +51,7 @@ def get_table_name_matches(conn, table_name_wildcard, separator):
             if table_name.startswith(table_name_wildcard.split("*", 1)[0]):
                 matching_tables.append(table_name)
         elif separator == '':
-            if table_name.startswith(re.sub( r"([A-Z])", r" \1", table_name_wildcard.split("*", 1)[0]).split()[0] ):
+            if table_name.startswith(re.sub(r"([A-Z])", r" \1", table_name_wildcard.split("*", 1)[0]).split()[0]):
                 matching_tables.append(table_name)
         elif table_name.split(separator, 1)[0] == table_name_wildcard.split("*", 1)[0]:
             matching_tables.append(table_name)
@@ -76,7 +76,7 @@ def get_restore_table_matches(table_name_wildcard, separator):
         if table_name_wildcard == "*":
             matching_tables.append(dir_name)
         elif separator == '':
-            if dir_name.startswith(re.sub( r"([A-Z])", r" \1", table_name_wildcard.split("*", 1)[0]).split()[0] ):
+            if dir_name.startswith(re.sub(r"([A-Z])", r" \1", table_name_wildcard.split("*", 1)[0]).split()[0]):
                 matching_tables.append(dir_name)
         elif dir_name.split(separator, 1)[0] == table_name_wildcard.split("*", 1)[0]:
             matching_tables.append(dir_name)
@@ -89,7 +89,7 @@ def change_prefix(source_table_name, source_wildcard, destination_wildcard, sepa
     destination_prefix = destination_wildcard.split("*", 1)[0]
     if separator == '':
         if re.sub( r"([A-Z])", r" \1", source_table_name).split()[0] == source_prefix:
-            return destination_prefix + re.sub( r"([A-Z])", r" \1", source_table_name).split(' ',1)[1].replace(" ", "")
+            return destination_prefix + re.sub(r"([A-Z])", r" \1", source_table_name).split(' ', 1)[1].replace(" ", "")
     if source_table_name.split(separator, 1)[0] == source_prefix:
         return destination_prefix + separator + source_table_name.split(separator, 1)[1]
 

--- a/dynamodump.py
+++ b/dynamodump.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import boto.dynamodb2.layer1, json, sys, time, shutil, os, argparse, logging, datetime, threading
+import boto.dynamodb2.layer1, json, sys, time, shutil, os, argparse, logging, datetime, threading, re
 from boto.dynamodb2.layer1 import DynamoDBConnection
 
 JSON_INDENT = 2
@@ -37,6 +37,9 @@ def get_table_name_matches(conn, table_name_wildcard, separator):
     elif separator == None:
       if table_name.startswith(table_name_wildcard.split("*", 1)[0]):
         matching_tables.append(table_name)
+    elif separator == '':
+      if table_name.startswith(re.sub( r"([A-Z])", r" \1", table_name_wildcard.split("*", 1)[0]).split()[0] ):
+        matching_tables.append(table_name)
     elif table_name.split(separator, 1)[0] == table_name_wildcard.split("*", 1)[0]:
       matching_tables.append(table_name)
 
@@ -58,6 +61,12 @@ def get_restore_table_matches(table_name_wildcard, separator):
   for dir_name in dir_list:
     if table_name_wildcard == "*":
       matching_tables.append(dir_name)
+    elif separator == None:
+      if dir_name.startswith(table_name_wildcard.split("*", 1)[0]):
+        matching_tables.append(dir_name)
+    elif separator == '':
+      if dir_name.startswith(re.sub( r"([A-Z])", r" \1", table_name_wildcard.split("*", 1)[0]).split()[0] ):
+        matching_tables.append(dir_name)
     elif dir_name.split(separator, 1)[0] == table_name_wildcard.split("*", 1)[0]:
       matching_tables.append(dir_name)
 
@@ -66,6 +75,9 @@ def get_restore_table_matches(table_name_wildcard, separator):
 def change_prefix(source_table_name, source_wildcard, destination_wildcard, separator):
   source_prefix = source_wildcard.split("*", 1)[0]
   destination_prefix = destination_wildcard.split("*", 1)[0]
+  if separator == '':
+    if re.sub( r"([A-Z])", r" \1", source_table_name).split()[0] == source_prefix:
+      return destination_prefix + re.sub( r"([A-Z])", r" \1", source_table_name).split(' ',1)[1].replace(" ", "")
   if source_table_name.split(separator, 1)[0] == source_prefix:
     return destination_prefix + separator + source_table_name.split(separator, 1)[1]
 


### PR DESCRIPTION
Used when tables are prefixed without a separtor e.g.
testTableOne
testTableTwo

can be backed up with:
./dynamodump.py -m 'backup' -r 'ap-southeast-2' --prefixSeparator '' -s 'test*'

and restored with:
./dynamodump.py -m ‘backup’ -r 'ap-southeast-2' --prefixSeparator '' -s 'test*' -d 'prod*'

Resulting restored tables would be:
prodTableOne
prodTableTwo