### PR TITLE
batch write sleep interval and provisioned capacity limits on data only restore

### DIFF
--- a/dynamodump.py
+++ b/dynamodump.py
@@ -16,7 +16,7 @@ from boto.dynamodb2.layer1 import DynamoDBConnection
 JSON_INDENT = 2
 AWS_SLEEP_INTERVAL = 10  # seconds
 LOCAL_SLEEP_INTERVAL = 1  # seconds
-BATCH_WRITE_SLEEP_INTERVAL = 0.15 # seconds
+BATCH_WRITE_SLEEP_INTERVAL = 0.15  # seconds
 MAX_BATCH_WRITE = 25  # DynamoDB limit
 SCHEMA_FILE = "schema.json"
 DATA_DIR = "data"
@@ -437,6 +437,7 @@ def do_restore(conn, sleep_interval, source_table, destination_table, write_capa
             datetime.datetime.now().replace(microsecond=0) - start_time))
     else:
         logging.info("Empty schema of " + source_table + " table created. Time taken: " + str(datetime.datetime.now().replace(microsecond=0) - start_time))
+
 
 # parse args
 parser = argparse.ArgumentParser(description="Simple DynamoDB backup/restore/empty.")

--- a/dynamodump.py
+++ b/dynamodump.py
@@ -16,6 +16,7 @@ from boto.dynamodb2.layer1 import DynamoDBConnection
 JSON_INDENT = 2
 AWS_SLEEP_INTERVAL = 10  # seconds
 LOCAL_SLEEP_INTERVAL = 1  # seconds
+BATCH_WRITE_SLEEP_INTERVAL = 0.15 # seconds
 MAX_BATCH_WRITE = 25  # DynamoDB limit
 SCHEMA_FILE = "schema.json"
 DATA_DIR = "data"
@@ -147,16 +148,18 @@ def mkdir_p(path):
 def batch_write(conn, sleep_interval, table_name, put_requests):
     request_items = {table_name: put_requests}
     i = 1
+    sleep = sleep_interval
     while True:
         response = conn.batch_write_item(request_items)
         unprocessed_items = response["UnprocessedItems"]
 
         if len(unprocessed_items) == 0:
             break
-
         if len(unprocessed_items) > 0 and i <= MAX_RETRY:
-            logging.debug(str(len(unprocessed_items)) + " unprocessed items, retrying.. [" + str(i) + "]")
+            logging.debug(str(len(unprocessed_items)) + " unprocessed items, retrying after %s seconds.. [%s/%s]" % (str(sleep), str(i), str(MAX_RETRY)))
             request_items = unprocessed_items
+            time.sleep(sleep)
+            sleep += sleep_interval
             i += 1
         else:
             logging.info("Max retries reached, failed to processed batch write: " + json.dumps(unprocessed_items,
@@ -390,12 +393,12 @@ def do_restore(conn, sleep_interval, source_table, destination_table, write_capa
                 # flush every MAX_BATCH_WRITE
                 if len(put_requests) == MAX_BATCH_WRITE:
                     logging.debug("Writing next " + str(MAX_BATCH_WRITE) + " items to " + destination_table + "..")
-                    batch_write(conn, sleep_interval, destination_table, put_requests)
+                    batch_write(conn, BATCH_WRITE_SLEEP_INTERVAL, destination_table, put_requests)
                     del put_requests[:]
 
             # flush remainder
             if len(put_requests) > 0:
-                batch_write(conn, sleep_interval, destination_table, put_requests)
+                batch_write(conn, BATCH_WRITE_SLEEP_INTERVAL, destination_table, put_requests)
 
         if not args.skipThroughputUpdate:
             # revert to original table write capacity if it has been modified

--- a/dynamodump.py
+++ b/dynamodump.py
@@ -433,6 +433,9 @@ def do_restore(conn, sleep_interval, source_table, destination_table, write_capa
                                 "Control plane limit exceeded, retrying updating throughput of GlobalSecondaryIndexes in " + destination_table + "..")
                             time.sleep(sleep_interval)
 
+        # wait for table to become active
+        wait_for_active_table(conn, destination_table, "active")
+
         logging.info("Restore for " + source_table + " to " + destination_table + " table completed. Time taken: " + str(
             datetime.datetime.now().replace(microsecond=0) - start_time))
     else:

--- a/test/test.py
+++ b/test/test.py
@@ -37,5 +37,6 @@ class TestDynamoDump(unittest.TestCase):
     def test_data(self):
         self.assertEqual(self.test_table_data, self.restored_test_table_data)
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I noticed that my restores were failing for two reasons:
- I did a `--dataOnly` restore, which doesn't update the capacity limits, so moved some code around to make that happen
- If you don't want to change the capacity limits for whatever reason, and the limits are too low, the batch write fails because it doesn't sleep between tries (I expected boto to do that but apparently it doesn't), I added a simple "linear sleep" which solves that (although it could be improved by using "exponential sleep" instead of linear)

These fixes work for me, I haven't tested it thoroughly. Hope it's useful!