### PR TITLE
Do restore if -s "*" is specified

### DIFF
--- a/dynamodump.py
+++ b/dynamodump.py
@@ -914,6 +914,8 @@ def main():
         try:
             if args.srcTable.find("*") == -1:
                 do_backup(conn, args.read_capacity, tableQueue=None)
+            else:
+                do_backup(conn, args.readCapacity, tableQueue=args.srcTable)
         except AttributeError:
             # Didn't specify srcTable if we get here
 


### PR DESCRIPTION
Running

python dynamodump.py -m backup -r eu-central-1 -s "*"  --accessKey XXX --secretKey XXX --schemaOnly

Didn't produce anything in dump. It seems that an else branch that restores all tables is missing.