### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+
+FROM python:2.7.14-alpine3.7
+
+WORKDIR /mnt/dynamodump
+COPY ./requirements.txt /mnt/dynamodump/requirements.txt
+COPY ./dynamodump.py /mnt/dynamodump/dynamodump.py
+
+RUN pip install -r requirements.txt
+
+


### PR DESCRIPTION
This adds a Dockerfile so this project can be linked on Dockerhub like this https://hub.docker.com/r/mattsurabian/dynamodump/.

Love this script but ran into trouble using it on a team where everyone had slightly different Python setups and experience debugging perms issues on pip install. Much easier to farm the work out to an ephemeral container.

If this is something you're open to adding to the project I'll definitely unpublish my image from hub and direct to the canonical one.

Thanks for a great utility.