### PR TITLE
Fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+env:
+  - BOTO_CONFIG=/dev/null
 python:
   - "2.7"
 install:
@@ -6,7 +8,7 @@ install:
   - pip install flake8
   - nvm install 4
   - nvm use 4
-  - npm install dynalite
+  - npm install -g dynalite
 script:
   - flake8 --ignore=E501 --exclude=node_modules
   - dynalite --port 4567 &


### PR DESCRIPTION
## GCE Issue
Boto loads code for GCE that we don't need by default causing a module not found error: https://github.com/travis-ci/travis-ci/issues/7940#issuecomment-311411559

errors:
https://travis-ci.org/bchew/dynamodump/builds/307938980?utm_source=github_status&utm_medium=notification
https://travis-ci.org/bchew/dynamodump/builds/307886425?utm_source=github_status&utm_medium=notification

## Dynalite Issue
Dynalite was not in the path and could not be run by CI
https://travis-ci.org/bchew/dynamodump/builds/326546745?utm_source=github_status&utm_medium=notification



  