### PR TITLE
Minor fix in do_get_s3_archive

### DIFF
--- a/dynamodump.py
+++ b/dynamodump.py
@@ -178,6 +178,7 @@ def do_get_s3_archive(profile, region, bucket, table, archive):
     try:
         contents = s3.list_objects_v2(
             Bucket=bucket,
+            Prefix=args.dumpPath
         )
     except botocore.exceptions.ClientError as e:
         logging.exception("Issue listing contents of bucket " + bucket + "\n\n" + str(e))
@@ -187,7 +188,7 @@ def do_get_s3_archive(profile, region, bucket, table, archive):
     # Therefore, just get item from bucket based on table name since that's what we name the files.
     filename = None
     for d in contents["Contents"]:
-        if d["Key"] == "dump/{}.{}".format(table, archive_type):
+        if d["Key"] == "{}/{}.{}".format(args.dumpPath, table, archive_type):
             filename = d["Key"]
 
     if not filename:


### PR DESCRIPTION
1. Added `Prefix` to the `s3.list_objects_v2` request to speed up the search.
1. Fixed a bug related to filename mapping during restore; should use `args.dumpPath` instead of`dump`.
