### PR TITLE
Fix loop on update_provisioned_throughput

### DIFF
--- a/dynamodump.py
+++ b/dynamodump.py
@@ -471,6 +471,9 @@ def update_provisioned_throughput(conn, table_name, read_capacity, write_capacit
                 logging.info("Control plane limit exceeded, retrying updating throughput"
                              "of " + table_name + "..")
                 time.sleep(sleep_interval)
+            elif e.body["message"] == "The requested throughput value equals the current value":
+                logging.info("Limit already set, no action is needed.")
+                break
 
     # wait for provisioned throughput update completion
     if wait:


### PR DESCRIPTION
While restoring dbs, update_provisioned_throughput is sometimes called
when not necessary. Handle the error condition there to identify that
the throughput matches the request and proceed, instead of looping
infinitely.

More logic could be added here to try to prevent infinite loops with unexpected
error messages. I prefer a light-touch, only changing what is minimally required
to progress.