### PR TITLE
chore: update Dockerfile to use python:3.9.0-alpine3.12 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-
-FROM python:2.7.14-alpine3.7
+FROM python:3.9.0-alpine3.12
 
 COPY ./requirements.txt /mnt/dynamodump/requirements.txt
 COPY ./dynamodump.py /usr/local/bin/dynamodump


### PR DESCRIPTION
Update Dockerfile to use python:3.9.0-alpine3.12 base image