### PR TITLE
Restore tables - Added another try to handle absolute path input arguments.

### DIFF
--- a/dynamodump.py
+++ b/dynamodump.py
@@ -307,15 +307,20 @@ def get_restore_table_matches(table_name_wildcard, separator):
     try:
         dir_list = os.listdir("./" + args.dumpPath)
     except OSError:
-        logging.info("Cannot find \"./%s\", Now trying current working directory.."
+        logging.info("Cannot find \"./%s\", Now trying user provided absolute dump path.."
                      % args.dumpPath)
-        dump_data_path = CURRENT_WORKING_DIR
         try:
-            dir_list = os.listdir(dump_data_path)
+            dir_list = os.listdir(args.dumpPath)
         except OSError:
-            logging.info("Cannot find \"%s\" directory containing dump files!"
+            logging.info("Cannot find \"%s\", Now trying current working directory.."
+                     % args.dumpPath)
+            dump_data_path = CURRENT_WORKING_DIR
+            try:
+                dir_list = os.listdir(dump_data_path)
+            except OSError:
+                logging.info("Cannot find \"%s\" directory containing dump files!"
                          % dump_data_path)
-            sys.exit(1)
+                sys.exit(1)
 
     for dir_name in dir_list:
         if table_name_wildcard == "*":


### PR DESCRIPTION
Hi bchew, Thanks for this wonderful script. We need to restore tables that are already backed up by the script and need to use an absolute path for the "--dumpPath" argument. I have made the changes, Kindly verify and approve my pull request.