### PR TITLE
feat: support absolute path for dumpPath

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,7 +6,7 @@ on:
     branches: [master]
 
 jobs:
-  build:
+  linting:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,26 +21,86 @@ jobs:
       - name: Set up DynamoDB Local
         run: |
           mkdir /tmp/dynamodb_local
-          wget -O - https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz | tar xz --directory /tmp/dynamodb_local
-          java -Djava.library.path=/tmp/dynamodb_local/DynamoDBLocal_lib -jar /tmp/dynamodb_local/DynamoDBLocal.jar -sharedDb -inMemory &
+          wget -O - https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz \
+            | tar xz --directory /tmp/dynamodb_local
+          java -Djava.library.path=/tmp/dynamodb_local/DynamoDBLocal_lib -jar /tmp/dynamodb_local/DynamoDBLocal.jar \
+            -sharedDb -inMemory &
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
       - name: Test basic restore and backup
         run: |
           mkdir dump && cp -a tests/testTable dump
-          python dynamodump/dynamodump.py -m restore --noConfirm -r local -s testTable -d testRestoredTable --host localhost --port 8000 --accessKey a --secretKey a
-          python dynamodump/dynamodump.py -m backup -r local -s testRestoredTable --host localhost --port 8000 --accessKey a --secretKey a
+          python dynamodump/dynamodump.py -m restore --noConfirm -r local -s testTable -d testRestoredTable \
+            --host localhost --port 8000 --accessKey a --secretKey a
+          python dynamodump/dynamodump.py -m backup -r local -s testRestoredTable --host localhost --port 8000 \
+            --accessKey a --secretKey a
           python tests/test.py
       - name: Test wildcard restore and backup
         run: |
-          python dynamodump/dynamodump.py -m restore --noConfirm -r local -s "*" --host localhost --port 8000 --accessKey a --secretKey a
+          python dynamodump/dynamodump.py -m restore --noConfirm -r local -s "*" --host localhost --port 8000 \
+            --accessKey a --secretKey a
           rm -rf dump/test*
-          python dynamodump/dynamodump.py -m backup -r local -s "*" --host localhost --port 8000 --accessKey a --secretKey a
+          python dynamodump/dynamodump.py -m backup -r local -s "*" --host localhost --port 8000 --accessKey a \
+            --secretKey a
           python tests/test.py
       - name: Test prefixed wildcard restore and backup
         run: |
-          python dynamodump/dynamodump.py -m restore --noConfirm -r local -s "test*" --host localhost --port 8000 --accessKey a --secretKey a --prefixSeparator ""
+          python dynamodump/dynamodump.py -m restore --noConfirm -r local -s "test*" --host localhost --port 8000 \
+            --accessKey a --secretKey a --prefixSeparator ""
           rm -rf dump/test*
-          python dynamodump/dynamodump.py -m backup -r local -s "test*" --host localhost --port 8000 --accessKey a --secretKey a --prefixSeparator ""
+          python dynamodump/dynamodump.py -m backup -r local -s "test*" --host localhost --port 8000 --accessKey a \
+            --secretKey a --prefixSeparator ""
           python tests/test.py
+      - name: Test non default dump path basic restore and backup
+        run: |
+          rm -rf dump
+          mkdir abc && cp -a tests/testTable abc
+          python dynamodump/dynamodump.py -m restore --noConfirm -r local -s testTable -d testRestoredTable \
+            --host localhost --port 8000 --accessKey a --secretKey a --dumpPath abc
+          rm -rf abc
+          python dynamodump/dynamodump.py -m backup -r local -s testRestoredTable --host localhost --port 8000 \
+            --accessKey a --secretKey a --dumpPath abc
+          DUMP_DATA_DIR=abc python tests/test.py
+      - name: Test non default dump path wildcard restore and backup
+        run: |
+          python dynamodump/dynamodump.py -m restore --noConfirm -r local -s "*" --host localhost --port 8000 \
+            --accessKey a --secretKey a --dumpPath abc
+          rm -rf abc/test*
+          python dynamodump/dynamodump.py -m backup -r local -s "*" --host localhost --port 8000 --accessKey a \
+            --secretKey a --dumpPath abc
+          DUMP_DATA_DIR=abc python tests/test.py
+      - name: Test non default dump path prefixed wildcard restore and backup
+        run: |
+          python dynamodump/dynamodump.py -m restore --noConfirm -r local -s "test*" --host localhost --port 8000 \
+            --accessKey a --secretKey a --prefixSeparator "" --dumpPath abc
+          rm -rf abc/test*
+          python dynamodump/dynamodump.py -m backup -r local -s "test*" --host localhost --port 8000 --accessKey a \
+            --secretKey a --prefixSeparator "" --dumpPath abc
+          DUMP_DATA_DIR=abc python tests/test.py
+      - name: Test non default absolute dump path basic restore and backup
+        run: |
+          rm -rf dump
+          mkdir /tmp/abs && cp -a tests/testTable /tmp/abs
+          python dynamodump/dynamodump.py -m restore --noConfirm -r local -s testTable -d testRestoredTable \
+            --host localhost --port 8000 --accessKey a --secretKey a --dumpPath /tmp/abs
+          rm -rf /tmp/abs
+          python dynamodump/dynamodump.py -m backup -r local -s testRestoredTable --host localhost --port 8000 \
+            --accessKey a --secretKey a --dumpPath /tmp/abs
+          DUMP_DATA_DIR=/tmp/abs python tests/test.py
+      - name: Test non default absolute dump path wildcard restore and backup
+        run: |
+          python dynamodump/dynamodump.py -m restore --noConfirm -r local -s "*" --host localhost --port 8000 \
+            --accessKey a --secretKey a --dumpPath /tmp/abs
+          rm -rf /tmp/abs/test*
+          python dynamodump/dynamodump.py -m backup -r local -s "*" --host localhost --port 8000 --accessKey a \
+            --secretKey a --dumpPath /tmp/abs
+          DUMP_DATA_DIR=/tmp/abs python tests/test.py
+      - name: Test non default absolute dump path prefixed wildcard restore and backup
+        run: |
+          python dynamodump/dynamodump.py -m restore --noConfirm -r local -s "test*" --host localhost --port 8000 \
+            --accessKey a --secretKey a --prefixSeparator "" --dumpPath /tmp/abs
+          rm -rf /tmp/abs/test*
+          python dynamodump/dynamodump.py -m backup -r local -s "test*" --host localhost --port 8000 --accessKey a \
+            --secretKey a --prefixSeparator "" --dumpPath /tmp/abs
+          DUMP_DATA_DIR=/tmp/abs python tests/test.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,11 @@ on:
     branches: [master]
 
 jobs:
-  build:
+  test-default-dump-path:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.9]
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -52,55 +51,101 @@ jobs:
           python dynamodump/dynamodump.py -m backup -r local -s "test*" --host localhost --port 8000 --accessKey a \
             --secretKey a --prefixSeparator ""
           python tests/test.py
+
+  test-non-default-dump-path:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+    env:
+      DUMP_PATH: abc
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up DynamoDB Local
+        run: |
+          mkdir /tmp/dynamodb_local
+          wget -O - https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz \
+            | tar xz --directory /tmp/dynamodb_local
+          java -Djava.library.path=/tmp/dynamodb_local/DynamoDBLocal_lib -jar /tmp/dynamodb_local/DynamoDBLocal.jar \
+            -sharedDb -inMemory &
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
       - name: Test non default dump path basic restore and backup
         run: |
-          rm -rf dump
-          mkdir abc && cp -a tests/testTable abc
+          mkdir ${{ env.DUMP_PATH }} && cp -a tests/testTable ${{ env.DUMP_PATH }}
           python dynamodump/dynamodump.py -m restore --noConfirm -r local -s testTable -d testRestoredTable \
-            --host localhost --port 8000 --accessKey a --secretKey a --dumpPath abc
-          rm -rf abc
+            --host localhost --port 8000 --accessKey a --secretKey a --dumpPath ${{ env.DUMP_PATH }}
+          rm -rf ${{ env.DUMP_PATH }}
           python dynamodump/dynamodump.py -m backup -r local -s testRestoredTable --host localhost --port 8000 \
-            --accessKey a --secretKey a --dumpPath abc
-          DUMP_DATA_DIR=abc python tests/test.py
+            --accessKey a --secretKey a --dumpPath ${{ env.DUMP_PATH }}
+          DUMP_DATA_DIR=${{ env.DUMP_PATH }} python tests/test.py
       - name: Test non default dump path wildcard restore and backup
         run: |
           python dynamodump/dynamodump.py -m restore --noConfirm -r local -s "*" --host localhost --port 8000 \
-            --accessKey a --secretKey a --dumpPath abc
-          rm -rf abc/test*
+            --accessKey a --secretKey a --dumpPath ${{ env.DUMP_PATH }}
+          rm -rf ${{ env.DUMP_PATH }}/test*
           python dynamodump/dynamodump.py -m backup -r local -s "*" --host localhost --port 8000 --accessKey a \
-            --secretKey a --dumpPath abc
-          DUMP_DATA_DIR=abc python tests/test.py
+            --secretKey a --dumpPath ${{ env.DUMP_PATH }}
+          DUMP_DATA_DIR=${{ env.DUMP_PATH }} python tests/test.py
       - name: Test non default dump path prefixed wildcard restore and backup
         run: |
           python dynamodump/dynamodump.py -m restore --noConfirm -r local -s "test*" --host localhost --port 8000 \
-            --accessKey a --secretKey a --prefixSeparator "" --dumpPath abc
-          rm -rf abc/test*
+            --accessKey a --secretKey a --prefixSeparator "" --dumpPath ${{ env.DUMP_PATH }}
+          rm -rf ${{ env.DUMP_PATH }}/test*
           python dynamodump/dynamodump.py -m backup -r local -s "test*" --host localhost --port 8000 --accessKey a \
-            --secretKey a --prefixSeparator "" --dumpPath abc
-          DUMP_DATA_DIR=abc python tests/test.py
-      - name: Test non default absolute dump path basic restore and backup
+            --secretKey a --prefixSeparator "" --dumpPath ${{ env.DUMP_PATH }}
+          DUMP_DATA_DIR=${{ env.DUMP_PATH }} python tests/test.py
+
+  test-absolute-dump-path:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.9]
+    env:
+      DUMP_PATH: /tmp/abs
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up DynamoDB Local
         run: |
-          rm -rf dump
-          mkdir /tmp/abs && cp -a tests/testTable /tmp/abs
+          mkdir /tmp/dynamodb_local
+          wget -O - https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz \
+            | tar xz --directory /tmp/dynamodb_local
+          java -Djava.library.path=/tmp/dynamodb_local/DynamoDBLocal_lib -jar /tmp/dynamodb_local/DynamoDBLocal.jar \
+            -sharedDb -inMemory &
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Test absolute dump path basic restore and backup
+        run: |
+          mkdir ${{ env.DUMP_PATH }} && cp -a tests/testTable ${{ env.DUMP_PATH }}
           python dynamodump/dynamodump.py -m restore --noConfirm -r local -s testTable -d testRestoredTable \
-            --host localhost --port 8000 --accessKey a --secretKey a --dumpPath /tmp/abs
-          rm -rf /tmp/abs
+            --host localhost --port 8000 --accessKey a --secretKey a --dumpPath ${{ env.DUMP_PATH }}
+          rm -rf ${{ env.DUMP_PATH }}
           python dynamodump/dynamodump.py -m backup -r local -s testRestoredTable --host localhost --port 8000 \
-            --accessKey a --secretKey a --dumpPath /tmp/abs
-          DUMP_DATA_DIR=/tmp/abs python tests/test.py
-      - name: Test non default absolute dump path wildcard restore and backup
+            --accessKey a --secretKey a --dumpPath ${{ env.DUMP_PATH }}
+          DUMP_DATA_DIR=${{ env.DUMP_PATH }} python tests/test.py
+      - name: Test absolute dump path wildcard restore and backup
         run: |
           python dynamodump/dynamodump.py -m restore --noConfirm -r local -s "*" --host localhost --port 8000 \
-            --accessKey a --secretKey a --dumpPath /tmp/abs
-          rm -rf /tmp/abs/test*
+            --accessKey a --secretKey a --dumpPath ${{ env.DUMP_PATH }}
+          rm -rf ${{ env.DUMP_PATH }}/test*
           python dynamodump/dynamodump.py -m backup -r local -s "*" --host localhost --port 8000 --accessKey a \
-            --secretKey a --dumpPath /tmp/abs
-          DUMP_DATA_DIR=/tmp/abs python tests/test.py
-      - name: Test non default absolute dump path prefixed wildcard restore and backup
+            --secretKey a --dumpPath ${{ env.DUMP_PATH }}
+          DUMP_DATA_DIR=${{ env.DUMP_PATH }} python tests/test.py
+      - name: Test absolute dump path prefixed wildcard restore and backup
         run: |
           python dynamodump/dynamodump.py -m restore --noConfirm -r local -s "test*" --host localhost --port 8000 \
-            --accessKey a --secretKey a --prefixSeparator "" --dumpPath /tmp/abs
-          rm -rf /tmp/abs/test*
+            --accessKey a --secretKey a --prefixSeparator "" --dumpPath ${{ env.DUMP_PATH }}
+          rm -rf ${{ env.DUMP_PATH }}/test*
           python dynamodump/dynamodump.py -m backup -r local -s "test*" --host localhost --port 8000 --accessKey a \
-            --secretKey a --prefixSeparator "" --dumpPath /tmp/abs
-          DUMP_DATA_DIR=/tmp/abs python tests/test.py
+            --secretKey a --prefixSeparator "" --dumpPath ${{ env.DUMP_PATH }}
+          DUMP_DATA_DIR=${{ env.DUMP_PATH }} python tests/test.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     env:
       DUMP_PATH: abc
     steps:
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     env:
       DUMP_PATH: /tmp/abs
     steps:

--- a/dynamodump/dynamodump.py
+++ b/dynamodump/dynamodump.py
@@ -343,16 +343,24 @@ def get_restore_table_matches(table_name_wildcard, separator):
         dir_list = os.listdir("./" + args.dumpPath)
     except OSError:
         logging.info(
-            'Cannot find "./%s", Now trying current working directory..' % args.dumpPath
+            'Cannot find "./%s", Now trying user provided absolute dump path..'
+            % args.dumpPath
         )
-        dump_data_path = CURRENT_WORKING_DIR
         try:
-            dir_list = os.listdir(dump_data_path)
+            dir_list = os.listdir(args.dumpPath)
         except OSError:
             logging.info(
-                'Cannot find "%s" directory containing dump files!' % dump_data_path
+                'Cannot find "%s", Now trying current working directory..'
+                % args.dumpPath
             )
-            sys.exit(1)
+            dump_data_path = CURRENT_WORKING_DIR
+            try:
+                dir_list = os.listdir(dump_data_path)
+            except OSError:
+                logging.info(
+                    'Cannot find "%s" directory containing dump files!' % dump_data_path
+                )
+                sys.exit(1)
 
     for dir_name in dir_list:
         if table_name_wildcard == "*":

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="dynamodump",
-    version="1.3.4",
+    version="1.4.0",
     author="Benny Chew",
     author_email="noreply@bennychew.com",
     description="Simple backup and restore for Amazon DynamoDB using AWS SDK for Python (boto3)",

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 import json
+import os
 import unittest
 
 TEST_DATA_PATH = "tests/testTable"
-DUMP_DATA_PATH = "dump/testRestoredTable"
+DUMP_DATA_DIR = os.getenv("DUMP_DATA_DIR", "dump")
+DUMP_DATA_PATH = f"{DUMP_DATA_DIR}/testRestoredTable"
 SCHEMA_FILE = "schema.json"
 DATA_FILE = "0001.json"
 


### PR DESCRIPTION
- Support absolute path usage for `dumpPath` argument (pulled from https://github.com/bchew/dynamodump/pull/68), thanks @Ram-dev06
- Add more tests to cover non-default and absolute dump path usages
- Refactored test GitHub Actions workflow to parallelise addtional tests, add Python versions >=3.6 to strategy matrix
- Bump version to 1.4.0