### PR TITLE
chore: update black in precommit to match dependabot upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 21.7b0
+    rev: 21.8b0
     hooks:
       - id: black
         language_version: python3.9


### PR DESCRIPTION
Update to match version from dependabot upgrade: https://github.com/bchew/dynamodump/pull/84