### PR TITLE
Fixes boto3 DynamoDB update_table API call

### DIFF
--- a/dynamodump/dynamodump.py
+++ b/dynamodump/dynamodump.py
@@ -954,7 +954,7 @@ def do_restore(dynamo, sleep_interval, source_table, destination_table, write_ca
                     try:
                         dynamo.update_table(
                             TableName=destination_table,
-                            global_secondary_index_updates=gsi_data,
+                            GlobalSecondaryIndexUpdates=gsi_data,
                         )
                         break
                     except dynamo.exceptions.LimitExceededException:


### PR DESCRIPTION
The boto3 API expects GlobalSecondaryIndexUpdates instead of global_secondary_index_updates in the parameter section of the method call. This PR fixes this single inconsistency of the API. Documentation of boto3 API call -> https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.update_table