### PR TITLE
Fix/restore dynamodump from backup with gsis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ dump
 dynamodump.iml
 env
 .vscode
+.idea

--- a/dynamodump/dynamodump.py
+++ b/dynamodump/dynamodump.py
@@ -755,8 +755,8 @@ def prepare_provisioned_throughput_for_restore(provisioned_throughput):
     See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html
     """
     return {
-        'ReadCapacityUnits': provisioned_throughput['ReadCapacityUnits'],
-        'WriteCapacityUnits': provisioned_throughput['WriteCapacityUnits']
+        "ReadCapacityUnits": provisioned_throughput["ReadCapacityUnits"],
+        "WriteCapacityUnits": provisioned_throughput["WriteCapacityUnits"],
     }
 
 
@@ -766,10 +766,12 @@ def prepare_gsi_for_restore(gsi):
     See: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html
     """
     return {
-        'IndexName': gsi['IndexName'],
-        'KeySchema': gsi['KeySchema'],
-        'Projection': gsi['Projection'],
-        'ProvisionedThroughput': prepare_provisioned_throughput_for_restore(gsi['ProvisionedThroughput'])
+        "IndexName": gsi["IndexName"],
+        "KeySchema": gsi["KeySchema"],
+        "Projection": gsi["Projection"],
+        "ProvisionedThroughput": prepare_provisioned_throughput_for_restore(
+            gsi["ProvisionedThroughput"]
+        ),
     }
 
 
@@ -838,7 +840,9 @@ def do_restore(dynamo, sleep_interval, source_table, destination_table, write_ca
         for gsi in table_global_secondary_indexes:
             # keeps track of original gsi write capacity units. If provisioned capacity is 0, set to
             # RESTORE_WRITE_CAPACITY as fallback given that 0 is not allowed for write capacities
-            original_gsi_write_capacity = gsi["ProvisionedThroughput"]["WriteCapacityUnits"]
+            original_gsi_write_capacity = gsi["ProvisionedThroughput"][
+                "WriteCapacityUnits"
+            ]
             if original_gsi_write_capacity == 0:
                 original_gsi_write_capacity = RESTORE_WRITE_CAPACITY
 
@@ -849,14 +853,21 @@ def do_restore(dynamo, sleep_interval, source_table, destination_table, write_ca
 
             # keeps track of original gsi read capacity units. If provisioned capacity is 0, set to
             # RESTORE_READ_CAPACITY as fallback given that 0 is not allowed for read capacities
-            original_gsi_read_capacity = gsi["ProvisionedThroughput"]["ReadCapacityUnits"]
+            original_gsi_read_capacity = gsi["ProvisionedThroughput"][
+                "ReadCapacityUnits"
+            ]
             if original_gsi_read_capacity == 0:
                 original_gsi_read_capacity = RESTORE_READ_CAPACITY
 
             original_gsi_read_capacities.append(original_gsi_read_capacity)
 
-            if gsi["ProvisionedThroughput"]["ReadCapacityUnits"] < RESTORE_READ_CAPACITY:
-                gsi["ProvisionedThroughput"]["ReadCapacityUnits"] = RESTORE_READ_CAPACITY
+            if (
+                gsi["ProvisionedThroughput"]["ReadCapacityUnits"]
+                < RESTORE_READ_CAPACITY
+            ):
+                gsi["ProvisionedThroughput"][
+                    "ReadCapacityUnits"
+                ] = RESTORE_READ_CAPACITY
 
     # temp provisioned throughput for restore
     table_provisioned_throughput = {
@@ -987,13 +998,18 @@ def do_restore(dynamo, sleep_interval, source_table, destination_table, write_ca
                     rcu = gsi["ProvisionedThroughput"]["ReadCapacityUnits"]
                     original_gsi_write_capacity = original_gsi_write_capacities.pop(0)
                     original_gsi_read_capacity = original_gsi_read_capacities.pop(0)
-                    if original_gsi_write_capacity != wcu or original_gsi_read_capacity != rcu:
+                    if (
+                        original_gsi_write_capacity != wcu
+                        or original_gsi_read_capacity != rcu
+                    ):
                         gsi_data.append(
                             {
                                 "Update": {
                                     "IndexName": gsi["IndexName"],
                                     "ProvisionedThroughput": {
-                                        "ReadCapacityUnits": int(original_gsi_read_capacity),
+                                        "ReadCapacityUnits": int(
+                                            original_gsi_read_capacity
+                                        ),
                                         "WriteCapacityUnits": int(
                                             original_gsi_write_capacity
                                         ),

--- a/dynamodump/dynamodump.py
+++ b/dynamodump/dynamodump.py
@@ -44,6 +44,7 @@ MAX_NUMBER_BACKUP_WORKERS = 25
 MAX_RETRY = 6
 METADATA_URL = "http://169.254.169.254/latest/meta-data/"
 RESTORE_WRITE_CAPACITY = 25
+RESTORE_READ_CAPACITY = 25
 SCHEMA_FILE = "schema.json"
 THREAD_START_DELAY = 1  # seconds
 
@@ -792,21 +793,49 @@ def do_restore(dynamo, sleep_interval, source_table, destination_table, write_ca
         else:
             write_capacity = original_write_capacity
 
+    if original_write_capacity == 0:
+        original_write_capacity = RESTORE_WRITE_CAPACITY
+
+    # ensure that read capacity is at least RESTORE_READ_CAPACITY
+    if original_read_capacity < RESTORE_READ_CAPACITY:
+        read_capacity = RESTORE_WRITE_CAPACITY
+    else:
+        read_capacity = original_read_capacity
+
+    if original_read_capacity == 0:
+        original_read_capacity = RESTORE_READ_CAPACITY
+
     # override GSI write capacities if specified, else use RESTORE_WRITE_CAPACITY if original
     # write capacity is lower
     original_gsi_write_capacities = []
+    original_gsi_read_capacities = []
     if table_global_secondary_indexes is not None:
         for gsi in table_global_secondary_indexes:
-            original_gsi_write_capacities.append(
-                gsi["ProvisionedThroughput"]["WriteCapacityUnits"]
-            )
+            # keeps track of original gsi write capacity units. If provisioned capacity is 0, set to
+            # RESTORE_WRITE_CAPACITY as fallback given that 0 is not allowed for write capacities
+            original_gsi_write_capacity = gsi["ProvisionedThroughput"]["WriteCapacityUnits"]
+            if original_gsi_write_capacity == 0:
+                original_gsi_write_capacity = RESTORE_WRITE_CAPACITY
+
+            original_gsi_write_capacities.append(original_gsi_write_capacity)
 
             if gsi["ProvisionedThroughput"]["WriteCapacityUnits"] < int(write_capacity):
                 gsi["ProvisionedThroughput"]["WriteCapacityUnits"] = int(write_capacity)
 
+            # keeps track of original gsi read capacity units. If provisioned capacity is 0, set to
+            # RESTORE_READ_CAPACITY as fallback given that 0 is not allowed for read capacities
+            original_gsi_read_capacity = gsi["ProvisionedThroughput"]["ReadCapacityUnits"]
+            if original_gsi_read_capacity == 0:
+                original_gsi_read_capacity = RESTORE_READ_CAPACITY
+
+            original_gsi_read_capacities.append(original_gsi_read_capacity)
+
+            if gsi["ProvisionedThroughput"]["ReadCapacityUnits"] < RESTORE_READ_CAPACITY:
+                gsi["ProvisionedThroughput"]["ReadCapacityUnits"] = RESTORE_READ_CAPACITY
+
     # temp provisioned throughput for restore
     table_provisioned_throughput = {
-        "ReadCapacityUnits": int(original_read_capacity),
+        "ReadCapacityUnits": int(read_capacity),
         "WriteCapacityUnits": int(write_capacity),
     }
 
@@ -930,13 +959,14 @@ def do_restore(dynamo, sleep_interval, source_table, destination_table, write_ca
                     wcu = gsi["ProvisionedThroughput"]["WriteCapacityUnits"]
                     rcu = gsi["ProvisionedThroughput"]["ReadCapacityUnits"]
                     original_gsi_write_capacity = original_gsi_write_capacities.pop(0)
-                    if original_gsi_write_capacity != wcu:
+                    original_gsi_read_capacity = original_gsi_read_capacities.pop(0)
+                    if original_gsi_write_capacity != wcu or original_gsi_read_capacity != rcu:
                         gsi_data.append(
                             {
                                 "Update": {
                                     "IndexName": gsi["IndexName"],
                                     "ProvisionedThroughput": {
-                                        "ReadCapacityUnits": int(rcu),
+                                        "ReadCapacityUnits": int(original_read_capacity),
                                         "WriteCapacityUnits": int(
                                             original_gsi_write_capacity
                                         ),
@@ -945,30 +975,31 @@ def do_restore(dynamo, sleep_interval, source_table, destination_table, write_ca
                             }
                         )
 
-                logging.info(
-                    "Updating "
-                    + destination_table
-                    + " global secondary indexes write capacities as necessary.."
-                )
-                while True:
-                    try:
-                        dynamo.update_table(
-                            TableName=destination_table,
-                            GlobalSecondaryIndexUpdates=gsi_data,
-                        )
-                        break
-                    except dynamo.exceptions.LimitExceededException:
-                        logging.info(
-                            "Limit exceeded, retrying updating throughput of"
-                            "GlobalSecondaryIndexes in " + destination_table + ".."
-                        )
-                        time.sleep(sleep_interval)
-                    except dynamo.exceptions.ProvisionedThroughputExceededException:
-                        logging.info(
-                            "Control plane limit exceeded, retrying updating throughput of"
-                            "GlobalSecondaryIndexes in " + destination_table + ".."
-                        )
-                        time.sleep(sleep_interval)
+                if gsi_data:
+                    logging.info(
+                        "Updating "
+                        + destination_table
+                        + " global secondary indexes write and read capacities as necessary.."
+                    )
+                    while True:
+                        try:
+                            dynamo.update_table(
+                                TableName=destination_table,
+                                GlobalSecondaryIndexUpdates=gsi_data,
+                            )
+                            break
+                        except dynamo.exceptions.LimitExceededException:
+                            logging.info(
+                                "Limit exceeded, retrying updating throughput of"
+                                "GlobalSecondaryIndexes in " + destination_table + ".."
+                            )
+                            time.sleep(sleep_interval)
+                        except dynamo.exceptions.ProvisionedThroughputExceededException:
+                            logging.info(
+                                "Control plane limit exceeded, retrying updating throughput of"
+                                "GlobalSecondaryIndexes in " + destination_table + ".."
+                            )
+                            time.sleep(sleep_interval)
 
         # wait for table to become active
         wait_for_active_table(dynamo, destination_table, "active")

--- a/dynamodump/dynamodump.py
+++ b/dynamodump/dynamodump.py
@@ -993,7 +993,7 @@ def do_restore(dynamo, sleep_interval, source_table, destination_table, write_ca
                                 "Update": {
                                     "IndexName": gsi["IndexName"],
                                     "ProvisionedThroughput": {
-                                        "ReadCapacityUnits": int(original_read_capacity),
+                                        "ReadCapacityUnits": int(original_gsi_read_capacity),
                                         "WriteCapacityUnits": int(
                                             original_gsi_write_capacity
                                         ),

--- a/dynamodump/dynamodump.py
+++ b/dynamodump/dynamodump.py
@@ -981,7 +981,10 @@ def do_restore(dynamo, sleep_interval, source_table, destination_table, write_ca
 
         if not args.skipThroughputUpdate:
             # revert to original table write capacity if it has been modified
-            if int(write_capacity) != original_write_capacity or int(read_capacity) != original_read_capacity:
+            if (
+                int(write_capacity) != original_write_capacity
+                or int(read_capacity) != original_read_capacity
+            ):
                 update_provisioned_throughput(
                     dynamo,
                     destination_table,

--- a/dynamodump/dynamodump.py
+++ b/dynamodump/dynamodump.py
@@ -981,7 +981,7 @@ def do_restore(dynamo, sleep_interval, source_table, destination_table, write_ca
 
         if not args.skipThroughputUpdate:
             # revert to original table write capacity if it has been modified
-            if int(write_capacity) != original_write_capacity:
+            if int(write_capacity) != original_write_capacity or int(read_capacity) != original_read_capacity:
                 update_provisioned_throughput(
                     dynamo,
                     destination_table,


### PR DESCRIPTION
When trying to restore tables that were generated using the backup functionality of dynamodump, the Table and GSI schema from the describe_table boto3 API call is not fully compatible with the create_table operation of the API. This PR makes sure that the correct payloads are passed to the create_table API call when GSIs are present in the backup data. It also makes sure that when a backup Table is configured in on-demand mode (provisioned throughput set to 0 for all WCU and RCU) the default value of RESTORE_WRITE_CAPACITY is used instead (otherwise the parameter validation of the API will fail).

Without these changes, the output of the process will throw the following error when restoring a table with GSIs:

```
Traceback (most recent call last):
  File "dynamodump/dynamodump/dynamodump.py", line 1389, in <module>
    main()
  File "dynamodump/dynamodump/dynamodump.py", line 1354, in main
    do_restore(
  File "dynamodump/dynamodump/dynamodump.py", line 831, in do_restore
    dynamo.create_table(
  File "/lib/python3.8/site-packages/botocore/client.py", line 386, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/lib/python3.8/site-packages/botocore/client.py", line 677, in _make_api_call
    request_dict = self._convert_to_request_dict(
  File "/lib/python3.8/site-packages/botocore/client.py", line 725, in _convert_to_request_dict
    request_dict = self._serializer.serialize_to_request(
  File "/lib/python3.8/site-packages/botocore/validate.py", line 337, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid value for parameter ProvisionedThroughput.ReadCapacityUnits, value: 0, valid min value: 1
Unknown parameter in GlobalSecondaryIndexes[0]: "IndexStatus", must be one of: IndexName, KeySchema, Projection, ProvisionedThroughput
Unknown parameter in GlobalSecondaryIndexes[0]: "IndexSizeBytes", must be one of: IndexName, KeySchema, Projection, ProvisionedThroughput
Unknown parameter in GlobalSecondaryIndexes[0]: "ItemCount", must be one of: IndexName, KeySchema, Projection, ProvisionedThroughput
Unknown parameter in GlobalSecondaryIndexes[0]: "IndexArn", must be one of: IndexName, KeySchema, Projection, ProvisionedThroughput
Unknown parameter in GlobalSecondaryIndexes[0].ProvisionedThroughput: "NumberOfDecreasesToday", must be one of: ReadCapacityUnits, WriteCapacityUnits
Invalid value for parameter GlobalSecondaryIndexes[0].ProvisionedThroughput.ReadCapacityUnits, value: 0, valid min value: 1
Unknown parameter in GlobalSecondaryIndexes[1]: "IndexStatus", must be one of: IndexName, KeySchema, Projection, ProvisionedThroughput
Unknown parameter in GlobalSecondaryIndexes[1]: "IndexSizeBytes", must be one of: IndexName, KeySchema, Projection, ProvisionedThroughput
Unknown parameter in GlobalSecondaryIndexes[1]: "ItemCount", must be one of: IndexName, KeySchema, Projection, ProvisionedThroughput
Unknown parameter in GlobalSecondaryIndexes[1]: "IndexArn", must be one of: IndexName, KeySchema, Projection, ProvisionedThroughput
Unknown parameter in GlobalSecondaryIndexes[1].ProvisionedThroughput: "NumberOfDecreasesToday", must be one of: ReadCapacityUnits, WriteCapacityUnits
Invalid value for parameter GlobalSecondaryIndexes[1].ProvisionedThroughput.ReadCapacityUnits, value: 0, valid min value: 1
```
