### PR TITLE
chore: update ecr uri to use custom alias

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           images: |
             ${{ github.repository }}
-            public.ecr.aws/a7p1j9f6/dynamodump
+            public.ecr.aws/${{ github.repository }}
             ghcr.io/${{ github.repository }}
       
       - name: Build and push Docker image


### PR DESCRIPTION
AWS approved `bchew` as custom alias for public ECR thus switching to that for consistency