### PR TITLE
pass endpoint_url for local dynamodb

### DIFF
--- a/dynamodump/dynamodump.py
+++ b/dynamodump/dynamodump.py
@@ -59,6 +59,7 @@ def _get_aws_client(
     region: str = None,
     secret_key: str = None,
     access_key: str = None,
+    endpoint_url: str = None,
 ):
     """
     Build connection to some AWS service.
@@ -103,6 +104,7 @@ def _get_aws_client(
             region_name=aws_region,
             aws_access_key_id=access_key,
             aws_secret_access_key=secret_key,
+            endpoint_url=endpoint_url
         )
     return client
 
@@ -1217,6 +1219,7 @@ def main():
             access_key=args.accessKey,
             secret_key=args.secretKey,
             region=args.region,
+            endpoint_url="http://" + args.host + ":" + args.port
         )
         sleep_interval = LOCAL_SLEEP_INTERVAL
     else:


### PR DESCRIPTION
hostname and port are ignored for local dynamodb. Thus, running a local dynamodb on a different port does not work.

This patch fixes this and probably includes a ton of side effects (mainly because I don't really do python). Nevertheless, I thought to open a PR should someone else run into this issue.