### PR TITLE
fix: fix entrypoint in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ COPY ./dynamodump/dynamodump.py /usr/local/bin/dynamodump
 
 RUN pip install -r /mnt/dynamodump/requirements.txt
 
-ENTRYPOINT ["dynamodump" , "-h" ]
+ENTRYPOINT ["dynamodump"]
+CMD ["-h"]


### PR DESCRIPTION
This issue was brought up in https://github.com/bchew/dynamodump/pull/111, fixed it instead to use `CMD` as the default flags per https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#entrypoint