### PR TITLE
Add filter option for backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ usage: dynamodump [-h] [-a {zip,tar}] [-b BUCKET]
                      [--writeCapacity WRITECAPACITY] [--schemaOnly]
                      [--dataOnly] [--noConfirm] [--skipThroughputUpdate]
                      [--billingMode BILLING_MODE] [--dumpPath DUMPPATH] [--log LOG]
+                     [-f FILTEROPTION]
 
 Simple DynamoDB backup/restore/empty.
 
@@ -110,6 +111,8 @@ optional arguments:
                         backups (defaults to use 'dump') [optional]
   --log LOG             Logging level - DEBUG|INFO|WARNING|ERROR|CRITICAL
                         [optional]
+  -f FILTEROPTION, --filterOption FILTEROPTION
+                        Filter option for backup, JSON file of which keys are ['FilterExpression', 'ExpressionAttributeNames', 'ExpressionAttributeValues']
 ```
 
 Backup files are stored in a 'dump' subdirectory, and are restored from there as well by default.

--- a/dynamodump/dynamodump.py
+++ b/dynamodump/dynamodump.py
@@ -1235,7 +1235,7 @@ def main():
     parser.add_argument(
         "-f",
         "--filterOption",
-        help="Filter option for backup, JSON file of which keys are ['FilterExpression', 'ExpressionAttributeNames', 'ExpressionAttributeValues']"
+        help="Filter option for backup, JSON file of which keys are ['FilterExpression', 'ExpressionAttributeNames', 'ExpressionAttributeValues']",
     )
     args = parser.parse_args()
 
@@ -1294,8 +1294,14 @@ def main():
     if args.filterOption is not None:
         with open(args.filterOption, "r") as f:
             filter_option = json.load(f)
-            if filter_option.keys() != set(("FilterExpression", "ExpressionAttributeNames", "ExpressionAttributeValues")):
-                raise Exception('Invalid filter option format')
+            if filter_option.keys() != set(
+                (
+                    "FilterExpression",
+                    "ExpressionAttributeNames",
+                    "ExpressionAttributeValues",
+                )
+            ):
+                raise Exception("Invalid filter option format")
 
     # do backup/restore
     start_time = datetime.datetime.now().replace(microsecond=0)
@@ -1326,9 +1332,19 @@ def main():
 
         try:
             if args.srcTable.find("*") == -1:
-                do_backup(conn, args.read_capacity, tableQueue=None, filterOption=filter_option)
+                do_backup(
+                    conn,
+                    args.read_capacity,
+                    tableQueue=None,
+                    filterOption=filter_option,
+                )
             else:
-                do_backup(conn, args.read_capacity, matching_backup_tables, filterOption=filter_option)
+                do_backup(
+                    conn,
+                    args.read_capacity,
+                    matching_backup_tables,
+                    filterOption=filter_option,
+                )
         except AttributeError:
             # Didn't specify srcTable if we get here
 


### PR DESCRIPTION
# What

Support for filter option when backup

# How

Use JSON file to get filter options provided by boto3

Accept only three options otherwise raise exception. 
**FilterExpression, ExpressionAttributeNames, ExpressionAttributeValues**

See descriptions in [here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#DynamoDB.Client.scan) 

