### PR TITLE
ci: add sonar.python.version to fix sonarcloud warning

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,1 @@
+sonar.python.version=3


### PR DESCRIPTION
Add `sonar.python.version` to fix sonarcloud warning