### PR TITLE
Resolve #156 Incompatible with Localstack

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ dynamodump -a tar -b some_s3_bucket -m restore -r us-east-1 -p profile -d destin
 ## Local example
 
 The following assumes your local DynamoDB is running on localhost:8000 and is accessible via 'a' as access/secret keys.
+You must specify the host to get local behavior.
 
 ```
 dynamodump -m backup -r local -s testTable --host localhost --port 8000 --accessKey a --secretKey a

--- a/dynamodump/dynamodump.py
+++ b/dynamodump/dynamodump.py
@@ -1124,7 +1124,7 @@ def main():
     )
     parser.add_argument(
         "--host",
-        help="Host of local DynamoDB. This parameter triggers going to a local environment. [required only for local]",
+        help="Host of local DynamoDB. This parameter initialises dynamodump for local DynamoDB testing [required only for local]",
     )
     parser.add_argument(
         "--port", help="Port of local DynamoDB [required only for local]"

--- a/dynamodump/dynamodump.py
+++ b/dynamodump/dynamodump.py
@@ -36,7 +36,6 @@ DATA_DUMP = "dump"
 DEFAULT_PREFIX_SEPARATOR = "-"
 CURRENT_WORKING_DIR = os.getcwd()
 JSON_INDENT = 2
-LOCAL_REGION = "local"
 LOCAL_SLEEP_INTERVAL = 1  # seconds
 LOG_LEVEL = "INFO"
 MAX_BATCH_WRITE = 25  # DynamoDB limit
@@ -1121,12 +1120,11 @@ def main():
         "-r",
         "--region",
         help="AWS region to use, e.g. 'us-west-1'. "
-        "Can use AWS_DEFAULT_REGION for local testing.  Use '"
-        + LOCAL_REGION
-        + "' for local DynamoDB testing",
+        "Can use any region for local testing",
     )
     parser.add_argument(
-        "--host", help="Host of local DynamoDB [required only for local]"
+        "--host",
+        help="Host of local DynamoDB. This parameter triggers going to a local environment. [required only for local]",
     )
     parser.add_argument(
         "--port", help="Port of local DynamoDB [required only for local]"
@@ -1250,7 +1248,7 @@ def main():
         sys.exit(1)
 
     # instantiate connection
-    if args.region == LOCAL_REGION:
+    if args.host:
         conn = _get_aws_client(
             service="dynamodb",
             access_key=args.accessKey,


### PR DESCRIPTION
I ran into this issue myself and was able to get the tool working by changing the behavior switch to key off of the use of the `host` parameter instead of the `local` region. This improves compatibility with other methods of mocking AWS behavior which strictly mimic the actual regions without breaking compatibility with local scripts since `host` was only used with `local` anyway.