### PR TITLE
ci: update black pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
-  - repo: https://github.com/ambv/black
-    rev: 23.7.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
     hooks:
       - id: black
-        language_version: python3.10
+        language_version: python3.11
   - repo: https://github.com/PyCQA/flake8
     rev: 6.1.0
     hooks:


### PR DESCRIPTION
Update black pre-commit as per integrations note in https://github.com/psf/black/releases/tag/23.9.0